### PR TITLE
Add filtering for multiple chapters in end story reflections

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -6,7 +6,7 @@
       "fields": [
         { "fieldPath": "reflectionId", "order": "ASCENDING" },
         { "fieldPath": "questionId", "order": "ASCENDING" },
-        { "fieldPath": "answer", "order": "ASCENDING" }
+        { "fieldPath": "submittedAt", "order": "DESCENDING" }
       ]
     }
   ]

--- a/src/models/counterModel.js
+++ b/src/models/counterModel.js
@@ -1,6 +1,17 @@
 import { firestore } from '../firebase'
 
-export const getDbReflectionResponsesCount = async (reflectionId, questionId) => {
+export const getDbReflectionResponsesCounts = async (reflectionIds) => {
+  try {
+    const countPromises = reflectionIds.map(reflectionId => getDbReflectionResponsesCount(reflectionId));
+    const counts = await Promise.all(countPromises);
+    const countSum = counts.reduce((acc, i) => acc + i, 0);
+    return countSum;
+  } catch (err) {
+    throw new Error(`Error at getDbReflectionResponsesCounts: ${err}`)
+  }
+}
+
+export const getDbReflectionResponsesCount = async (reflectionId) => {
   try {
     const counter = await firestore
       .collection('counters')

--- a/src/models/reflectionResponseModel.js
+++ b/src/models/reflectionResponseModel.js
@@ -25,15 +25,15 @@ const populateDbUserOnReflectionResponse = async (reflectionResponse) => {
 export const getDbReflectionResponsesPaginated = async ({
   lastDocSnapshot,
   limit,
-  reflectionId,
+  reflectionIds,
   questionId,
 }) => {
   try {
     let query = firestore.collection('reflectionResponses')
-      .where('reflectionId', '==', reflectionId)
+      .where('reflectionId', 'in', reflectionIds)
       .where('questionId', '==', questionId)
       // .where('answer', '!=', '')  // TODO: uncomment after composite index is deployed
-      // .orderBy('submittedAt', 'desc')
+      .orderBy('submittedAt', 'desc')
       .limit(limit);
     if (lastDocSnapshot) {
       query = query.startAfter(lastDocSnapshot);

--- a/src/pages/ReflectionsPage/chapter/ChapterReflectionResponses.js
+++ b/src/pages/ReflectionsPage/chapter/ChapterReflectionResponses.js
@@ -113,7 +113,7 @@ const ChapterReflectionResponses = ({ reflectionId, setPage }) => {
     const { newResponses, newLastDocSnapshot } = await getDbReflectionResponsesPaginated({
       lastDocSnapshot,
       limit: LIMIT,
-      reflectionId,
+      reflectionIds: [reflectionId],
       questionId: 3,  // this is hardcoded to the "share your story textarea question"
     });
     if (newResponses.length < LIMIT) {
@@ -130,7 +130,7 @@ const ChapterReflectionResponses = ({ reflectionId, setPage }) => {
   }
 
   async function fetchCount() {
-    setCount(await getDbReflectionResponsesCount(reflectionId, 3));
+    setCount(await getDbReflectionResponsesCount(reflectionId));
   }
 
   useEffect(() => fetchCount(), []);

--- a/src/pages/StoryEndPage/steps/ReflectionIntroStep.js
+++ b/src/pages/StoryEndPage/steps/ReflectionIntroStep.js
@@ -82,7 +82,7 @@ const ReflectionIntroStep = ({ next , reflectionId }) => {
 
 
   async function fetchCount() {
-    setCount(await getDbReflectionResponsesCount(reflectionId, 3));
+    setCount(await getDbReflectionResponsesCount(reflectionId));
   }
 
   useEffect(() => fetchCount(), []);

--- a/src/pages/StoryEndPage/steps/ReflectionResponsesStep.js
+++ b/src/pages/StoryEndPage/steps/ReflectionResponsesStep.js
@@ -162,7 +162,6 @@ const ReflectionResponsesStep = ({ reflectionId, next }) => {
   }
 
   async function fetchCount() {
-    console.log(chosenReflectionId);
     setCount(await getDbReflectionResponsesCount(chosenReflectionId, 3));
   }
 
@@ -177,36 +176,6 @@ const ReflectionResponsesStep = ({ reflectionId, next }) => {
   useEffect(() => fetchCount(), [chosenReflectionId]);
   useEffect(() => fetchMoreResponsesIfNotOverflow(), [hasMore, lastDocSnapshot, chosenReflectionId]);
 
-  const LoadingBox = () => (
-    <Box className={classes.background}>
-      <PacmanLoader color="#e5e5e5" size={25} css={{ align: "center", top: "200px", left: "100px" }} />
-    </Box>
-  );
-
-  const ReflectionsBox = () => (
-    <Box className={classes.background}>
-      <Container className={classes.container} id={'reflectionsContainerId'}>
-        <Typography className={classes.headerText}>Reflections from Others</Typography>
-        <Typography variant="body2" color="error">{count || 0} players have completed this chapter</Typography>
-        <Box>
-          <InfiniteScroll
-            dataLength={responses.length}
-            next={fetchMoreResponses}
-            hasMore={hasMore}
-            loader={<PacmanLoader color="#e5e5e5" size={10} css={{display:'flex', left:'-15px', margin:'auto', height:'30px'}} />}
-            scrollableTarget={'reflectionsContainerId'}
-          >
-            {responses.map(response => (
-              response.answer.length > 5 && <ChapterResponse key={response.id} response={response} />
-            ))}
-          </InfiniteScroll>
-        </Box>
-      </Container>
-      <Button className={classes.btn} onClick={toggleFilterDrawer(true)}><TuneIcon /></Button>
-      <Button className={classes.btn} onClick={next}>Continue</Button>
-    </Box>
-  );
-
   return (
     <React.Fragment key='bottom'>
       <SwipeableDrawer
@@ -217,10 +186,37 @@ const ReflectionResponsesStep = ({ reflectionId, next }) => {
       >
         <FilterDrawer />
       </SwipeableDrawer>
-      { responses == null ? <LoadingBox/> : <ReflectionsBox/> }
+      { responses === null
+        ?
+        <Box className={classes.background}>
+          <PacmanLoader color="#e5e5e5" size={25} css={{ align: "center", top: "200px", left: "100px" }} />
+        </Box>
+        :
+        <Box className={classes.background}>
+          <Container className={classes.container} id={'reflectionsContainerId'}>
+            <Typography className={classes.headerText}>Reflections from Others</Typography>
+            <Typography variant="body2" color="error">{count || 0} players have completed this chapter</Typography>
+            <Box>
+              <InfiniteScroll
+                dataLength={responses.length}
+                next={fetchMoreResponses}
+                hasMore={hasMore}
+                loader={<PacmanLoader color="#e5e5e5" size={10} css={{ display: 'flex', left: '-15px', margin: 'auto', height: '30px' }} />}
+                scrollableTarget={'reflectionsContainerId'}
+              >
+                {responses.map(response => (
+                  response.answer.length > 5 && <ChapterResponse key={response.id} response={response} />
+                ))}
+              </InfiniteScroll>
+            </Box>
+          </Container>
+          <Button className={classes.btn} onClick={toggleFilterDrawer(true)}><TuneIcon /></Button>
+          <Button className={classes.btn} onClick={next}>Continue</Button>
+        </Box>
+      }
     </React.Fragment>
   );
-    
+
 }
 
 export default ReflectionResponsesStep;


### PR DESCRIPTION
1. Fixes the bug where it scrolls to the top every time new reflections are loaded
2. Add buttons for selecting multiple chapters at once + buttons for reset and apply
3. Sorts reflections in reverse chronological order (it works, but a new Firestore index is needed for this)

<img width="480" alt="Screenshot 2021-09-21 at 3 27 46 PM" src="https://user-images.githubusercontent.com/41856541/134129410-ace72fea-ec04-459a-b8f7-d95edd57323c.png">

What should happen if the user selects none of the chapters and tries to apply the filter?