### PR TITLE
add templating capability for reflections

### DIFF
--- a/src/components/ReflectionForm/EndStoryReflectionForm.js
+++ b/src/components/ReflectionForm/EndStoryReflectionForm.js
@@ -78,7 +78,7 @@ const useStyles = makeStyles((theme) => ({
   }
 }))
 
-const EndStoryReflectionForm = ({ subtitle, title, questions: propsQuestions, onSubmit, onSuccess, onError, chaptFeedback }) => {
+const EndStoryReflectionForm = ({ context, subtitle, title, questions: propsQuestions, onSubmit, onSuccess, onError, chaptFeedback }) => {
   const classes = useStyles();
 
   const questions = propsQuestions.map(id => QUESTIONS.find(question => question.id === id));
@@ -139,6 +139,7 @@ const EndStoryReflectionForm = ({ subtitle, title, questions: propsQuestions, on
           <Question
             key={question.id}
             question={question}
+            context={context}
             value={answers[index]}
             onChange={answer => setAnswers(
               produce(draftAnswers => {

--- a/src/components/ReflectionForm/Question.js
+++ b/src/components/ReflectionForm/Question.js
@@ -2,7 +2,9 @@ import { useState } from 'react';
 import { Typography, Box, TextField, Slider, RadioGroup, Radio, FormControlLabel } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 
-const useStyles = makeStyles((theme) => ({
+import formatString from '../../helpers/formatString';
+
+const useStyles = makeStyles(() => ({
   imageChoiceContainer: {
     display: 'flex',
     overflowX: 'scroll',
@@ -31,11 +33,13 @@ const useStyles = makeStyles((theme) => ({
     marginTop: 0,
     border: '2px solid red',
   },
-}))
+}));
 
-const Question = ({ question, value, onChange }) => {
+const Question = ({ question, value, onChange, context }) => {
   const classes = useStyles();
   const [answerLength, setAnswerLength] = useState(0);
+
+  const body = formatString(question.body, context);
 
   const handleChange = (event) => {
     onChange(event.target.value);
@@ -46,11 +50,11 @@ const Question = ({ question, value, onChange }) => {
       return (
         <Box p={2} bgcolor="rgba(255,255,255)">
           <Typography variant="body1">
-            <b>{question.body}</b>
+            <b>{body}</b>
           </Typography>
           <RadioGroup value={value} onChange={handleChange}>
             {question.choices.map(choice => (
-              <FormControlLabel key={choice.body} value={choice.body} control={<Radio />} label={choice.body}  />
+              <FormControlLabel key={choice.body} value={choice.body} control={<Radio />} label={formatString(choice.body, context)}  />
             ))}
           </RadioGroup>
         </Box>
@@ -59,7 +63,7 @@ const Question = ({ question, value, onChange }) => {
       return (
         <Box p={2} bgcolor="rgba(255,255,255,0.6)">
           <Typography variant="body1">
-            <b>{question.body}</b>
+            <b>{body}</b>
           </Typography>
           <Box className={classes.imageChoiceContainer}>
             {question.choices.map(choice => (
@@ -68,13 +72,13 @@ const Question = ({ question, value, onChange }) => {
                   className={value === choice.body
                     ? `${classes.imageChoiceImg} ${classes.imageChoiceImgSelected}`
                     : classes.imageChoiceImg}
-                  alt={choice.body}
+                  alt={formatString(choice.body, context)}
                   src={choice.image_url}
                   onClick={() => handleChange({
                     target: { value: choice.body }
                   })}
                 />
-                <b>{choice.body}</b>
+                <b>{formatString(choice.body, context)}</b>
               </Box>
             ))}
           </Box>
@@ -84,18 +88,18 @@ const Question = ({ question, value, onChange }) => {
       return (
         <Box p={2} bgcolor="rgba(255,255,255,0.6)">
           <Typography variant="body1">
-            <b>{question.body}</b>
+            <b>{body}</b>
           </Typography>
           <Box mt={2}>
             <Box display="flex" justifyContent="space-between">
               <Box>
                 <Typography variant="body1">
-                  {question.leftChoice.body}
+                  {formatString(question.leftChoice.body, context)}
                 </Typography>
               </Box>
               <Box>
                 <Typography variant="body1">
-                  {question.rightChoice.body}
+                  {formatString(question.rightChoice.body, context)}
                 </Typography>
               </Box>
             </Box>
@@ -108,7 +112,7 @@ const Question = ({ question, value, onChange }) => {
       return (
         <Box p={2} bgcolor="rgba(255,255,255,0.6)">
           <Typography variant="body1">
-            <b>{question.body}</b>
+            <b>{body}</b>
           </Typography>
           <Box mt={2}>
             <TextField

--- a/src/components/ReflectionForm/index.js
+++ b/src/components/ReflectionForm/index.js
@@ -94,6 +94,7 @@ const ReflectionForm = ({ reflection }) => {
           <Question
             key={question.id}
             question={question}
+            context={reflection.context}
             value={answers[index]}
             onChange={answer => setAnswers(
               produce(draftAnswers => {

--- a/src/helpers/formatString.js
+++ b/src/helpers/formatString.js
@@ -1,0 +1,10 @@
+const formatString = (template, values) => {
+  return template.replace(/{([a-zA-Z_]+)}/g, (match, field) => { 
+    return values?.[field] != null
+      ? values?.[field]
+      : match
+    ;
+  });
+};
+
+export default formatString;

--- a/src/pages/ReflectionsPage/shared/Question.js
+++ b/src/pages/ReflectionsPage/shared/Question.js
@@ -1,8 +1,9 @@
 import { Typography, Box, TextField, Slider, RadioGroup, Radio, FormControlLabel } from '@material-ui/core';
 import React, { useState, useEffect } from 'react';
 import { getDbReflectionResponsesChoiceCount } from '../../../models/counterModel';
+import formatString from '../../../helpers/formatString';
 
-const Question = ({ question, value, onChange, reflectionId}) => {
+const Question = ({ question, value, onChange, reflectionId, context }) => {
 
   const [counts, setCounts] = useState(null);
   const [answerLength, setAnswerLength] = useState(0);
@@ -17,6 +18,7 @@ const Question = ({ question, value, onChange, reflectionId}) => {
     setCounts(results);
   }
 
+  const body = formatString(question.body, context);
 
   const handleChange = (event) => {
     onChange(event.target.value);
@@ -27,11 +29,11 @@ const Question = ({ question, value, onChange, reflectionId}) => {
       return (
         <Box p={2} bgcolor="rgba(255,255,255,0.6)">
           <Typography variant="body1">
-            <b>{question.body}</b>
+            <b>{body}</b>
           </Typography>
           <RadioGroup value={value} onChange={handleChange}>
             {question.choices.map((choice) => (
-              <FormControlLabel key={choice.body} value={choice.body} control={<Radio />} label={choice.body}  />
+              <FormControlLabel key={choice.body} value={choice.body} control={<Radio />} label={formatString(choice.body, context)}  />
             ))}
           </RadioGroup>
         </Box>
@@ -40,18 +42,18 @@ const Question = ({ question, value, onChange, reflectionId}) => {
       return (
         <Box p={2} bgcolor="rgba(255,255,255,0.6)">
           <Typography variant="body1">
-            <b>{question.body}</b>
+            <b>{body}</b>
           </Typography>
           <Box mt={2}>
             <Box display="flex" justifyContent="space-between">
               <Box>
                 <Typography variant="body1">
-                  {question.leftChoice.body}
+                  {formatString(question.leftChoice.body, context)}
                 </Typography>
               </Box>
               <Box>
                 <Typography variant="body1">
-                  {question.rightChoice.body}
+                  {formatString(question.rightChoice.body, context)}
                 </Typography>
               </Box>
             </Box>
@@ -64,7 +66,7 @@ const Question = ({ question, value, onChange, reflectionId}) => {
       return (
         <Box p={2} bgcolor="rgba(255,255,255,0.6)">
           <Typography variant="body1">
-            <b>{question.body}</b>
+            <b>{body}</b>
           </Typography>
           <Box mt={2}>
             <TextField

--- a/src/pages/ReflectionsPage/shared/ReflectionForm.js
+++ b/src/pages/ReflectionsPage/shared/ReflectionForm.js
@@ -113,6 +113,7 @@ const ReflectionForm = ({ reflection }) => {
             reflectionId={reflection.id}
             key={question.id}
             question={question}
+            context={reflection.context}
             value={answers[index]}
             onChange={answer => setAnswers(
               produce(draftAnswers => {

--- a/src/pages/StoryEndPage/steps/LongFeedbackStep.js
+++ b/src/pages/StoryEndPage/steps/LongFeedbackStep.js
@@ -56,7 +56,7 @@ const LongFeedbackStep = ({ reflection, questions, characterId, setState, getSta
     })
   };
 
-  return <ReflectionForm questions={reflection.longQuestions} onSubmit={handleSubmit} onSuccess={handleSuccess} onError={handleError} />;
+  return <ReflectionForm context={reflection.context} questions={reflection.longQuestions} onSubmit={handleSubmit} onSuccess={handleSuccess} onError={handleError} />;
 };
 
 export default LongFeedbackStep;

--- a/src/pages/StoryEndPage/steps/QuickFeedbackStep.js
+++ b/src/pages/StoryEndPage/steps/QuickFeedbackStep.js
@@ -12,6 +12,7 @@ const QuickFeedbackStep = ({ reflection, setState, next }) => {
       subtitle="OVER TO YOU"
       title="Chapter Feedback"
       questions={reflection.quickQuestions}
+      context={reflection.context}
       onSubmit={handleSubmit}
     />
   );

--- a/src/reflections/questions.json
+++ b/src/reflections/questions.json
@@ -2,7 +2,7 @@
   {
     "id": 1,
     "type": "MULTI_CHOICE",
-    "body": "How did this part of the character's story make you feel?",
+    "body": "How did this part of {character_name}'s story make you feel?",
     "choices": [
       {
         "id":1,
@@ -41,7 +41,7 @@
   {
     "id": 2,
     "type": "LIKERT_SCALE",
-    "body": "How much did you get into the character's head?",
+    "body": "How much did you get into {character_name}'s head?",
     "leftChoice": {
       "body": "I'm not them."
     },
@@ -80,7 +80,7 @@
   {
     "id": 5,
     "type": "MULTI_CHOICE",
-    "body": "Which of the choices did you find the most challenging for Nadia?",
+    "body": "Which of the choices did you find the most challenging for {character_name}?",
     "choices": [
       {
         "id":1,
@@ -103,7 +103,7 @@
   {
     "id": 6,
     "type": "MULTI_CHOICE",
-    "body": "Which of the situations did you find the most challenging for Nadia?",
+    "body": "Which of the situations did you find the most challenging for {character_name}?",
     "choices": [
       {
         "id":1,
@@ -141,7 +141,7 @@
   {
     "id": 8,
     "type": "MULTI_CHOICE_IMAGE",
-    "body": "Which character do you most resonate with in the character’s journey?",
+    "body": "Which character do you most resonate with in {character_name}’s journey?",
     "choices": [
       {
         "id":1,
@@ -168,7 +168,7 @@
   {
     "id": 9,
     "type": "MULTI_CHOICE",
-    "body": "How do you think the main character is feeling now?",
+    "body": "How do you think {character_name} is feeling now?",
     "choices": [
       {
         "id":1,

--- a/src/reflections/reflections.json
+++ b/src/reflections/reflections.json
@@ -5,6 +5,9 @@
     "chapter":1,
     "didyouknow": "This story is based on focus group interviews with members from this community, and deals with an important element of the Sikh identiity. ",
     "media": "https://www.ricemedia.co/culture-people-daggers-bracelets-and-boxer-shorts-the-religious-articles-of-sikhs/",
+    "context": {
+      "character_name": "Aman"
+    },
     "questions": [
       1,      
       4,
@@ -18,6 +21,9 @@
     "chapter":1,
     "didyouknow": "This story is based on real stories of inter-faith relationships, and of understanding your own faith as a young adult. There are hidden struggles that many go through.",
     "media": "https://www.ricemedia.co/culture-people-conversion-circumcision-angry-mum-journey-one-couples-interracial-marriage-nhb/",
+    "context": {
+      "character_name": "Nadia"
+    },
     "questions": [
       1,
       5,
@@ -31,6 +37,9 @@
     "chapter":2,
     "didyouknow": "There were many serious issues raised in this chapter, and it may help to research more and discuss these issues with trusted friends from other communities.",
     "media": "https://www.channelnewsasia.com/news/singapore/is-casual-racism-okay-seven-singaporeans-share-stories-7862072",
+    "context": {
+      "character_name": "Nadia"
+    },
     "questions": [
       1,      
       6,
@@ -45,6 +54,9 @@
     "media": "https://www.facebook.com/mosg.tv/videos/705929542901799/",
     "mediatype" : "video",
     "mediaimage" : "/didyouknow/nadia_video.png",
+    "context": {
+      "character_name": "Nadia"
+    },
     "quickQuestions": [     
       9,      
       2,


### PR DESCRIPTION
This PR adds templating capabilities for reflection questions.

For example, in Nadia's reflections, you can now write `How did you feel about {character_name}?` and it would show up as `How did you feel about Nadia?`.

Inputs are introduced statically through the `context` field in `reflections.json`. Check out `reflections.json` in "File Changes" tab for an example. This isn't a design choice, I simply could not find any useful values returned from `useInkContext`, so I used the JSON file instead to introduce the context.

There is no support for nested values, so templates like `character.name` will _not work_.