### PR TITLE
fix share step

### DIFF
--- a/src/pages/ShareableImage/ShareableImageContainer.js
+++ b/src/pages/ShareableImage/ShareableImageContainer.js
@@ -149,6 +149,9 @@ const ShareableImageContainer = ({data }) =>{
     if (text.length > 200) {
         displayText = text.slice(0,198)+"..."
     }
+    else if (text.length == 0) {
+      displayText = "I completed playing the interactive fiction game ToBeYou.sg, and I want you to join me!"
+    }
     else {
         displayText = text
     }

--- a/src/pages/ShareableImage/ShareableImageContainer.js
+++ b/src/pages/ShareableImage/ShareableImageContainer.js
@@ -181,7 +181,7 @@ const ShareableImageContainer = ({data }) =>{
       
       {/* <button onClick={loadImage}>Pre-load image</button> */}
       <img width={width} src={image} alt={"ScreenShot"} className="ShareableImage" />
-      <Button variant="contained"  className={classes.btn} onClick={getImage} >{isMobile ? 'Share via Mobile' : 'Download Image'} </Button>
+      <Button variant="contained"  className={classes.btn} onClick={getImage} >{isMobile ? 'Share reflection' : 'Download Image'} </Button>
       {/* <button onClick={getImage} className="btn">{isMobile ? 'Share via Mobile' : 'Download Image'}</button> */}
   </div>
   )};


### PR DESCRIPTION
set default text in shareable image for case of empty reflection responses
updated share/download button text to accommodate 'download' case in older iOS versions