### PR TITLE
Add cloud functions to manage denormalised fields: `participantRoomIds` and `facilitators`

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -5,6 +5,9 @@ admin.initializeApp();
 const firestore = admin.firestore();
 const FieldValue = admin.firestore.FieldValue;
 
+
+// Reflection counters
+
 exports.incrementReflectionCounters = functions.firestore
   .document('reflectionResponses/{docId}')
   .onCreate(async (snap, context) => {
@@ -45,4 +48,135 @@ exports.incrementReflectionChoiceCounters = functions.firestore
     } else {
       await choiceRef.update({ count: FieldValue.increment(1) });
     }
+  });
+
+
+// Participant room IDs: for saved states, reflection responses, and quiz answers
+
+/**
+ * When a participant joins or leaves a room, add or delete the room accordingly from
+ * the `participantRoomIds` field of all their saved states/reflection responses/quiz answers
+ */
+exports.updateParticipantRoomIds = functions.firestore
+  .document('rooms/{docId}')
+  .onWrite(async (change, context) => {
+    function difference(arr1, arr2) {  // arr1 - arr2
+      return arr1.filter(x => !arr2.includes(x));
+    }
+
+    // Adds the room ID to all of the participant's documents in the collection
+    async function addRoomIdToParticipantDocuments(participantId, roomId, collection) {
+      const snapshot = await firestore
+        .collection(collection)
+        .where('userId', '==', participantId)
+        .get();
+      await Promise.all(snapshot.docs.map(async (doc) => {
+        const existingParticipantRoomIds = doc.data().participantRoomIds || [];
+        const newParticipantRoomIds = [...existingParticipantRoomIds, roomId];
+        return firestore
+          .collection(collection)
+          .doc(doc.id)
+          .update({ participantRoomIds: newParticipantRoomIds });
+      }));
+    }
+
+    // Deletes the room ID from all of the participant's documents in the collection
+    async function deleteRoomIdFromParticipantDocuments(participantId, roomId, collection) {
+      const snapshot = await firestore
+        .collection(collection)
+        .where('userId', '==', participantId)
+        .get();
+      await Promise.all(snapshot.docs.map(async (doc) => {
+        const existingParticipantRoomIds = doc.data().participantRoomIds || [];
+        const newParticipantRoomIds = existingParticipantRoomIds.filter(x => x !== roomId);
+        const docRef = firestore.collection(collection).doc(doc.id);
+        if (newParticipantRoomIds.length > 0) {
+          return docRef.update({ participantRoomIds: newParticipantRoomIds });
+        } else {
+          return docRef.update({ participantRoomIds: FieldValue.delete() });
+        }
+      }));
+    }
+
+    const roomId = change.before.id;
+    const beforeParticipantIds = change.before.exists ? change.before.data().participantIds : [];
+    const afterParticipantIds = change.after.exists ? change.after.data().participantIds : [];
+    const addedParticipantIds = difference(afterParticipantIds, beforeParticipantIds);
+    const deletedParticipantIds = difference(beforeParticipantIds, afterParticipantIds);
+
+    const collections = ['savedStates', 'reflectionResponses', 'quizAnswers'];
+    for (const collection of collections) {
+      await Promise.all(addedParticipantIds.map(async (addedParticipantId) => {
+        return await addRoomIdToParticipantDocuments(addedParticipantId, roomId, collection);
+      }));
+      await Promise.all(deletedParticipantIds.map(async (deletedParticipantId) => {
+        return await deleteRoomIdFromParticipantDocuments(deletedParticipantId, roomId, collection);
+      }));
+    }
+  });
+
+/**
+ * When a new saved state/reflection response/quiz answer is created,
+ * add its `participantRoomIds` field automatically
+ */
+async function addParticipantRoomIds(snap, context) {
+  const { userId } = snap.data();
+  const snapshot = await firestore
+    .collection('rooms')
+    .where('participantIds', 'array-contains', userId)
+    .get();
+  if (snapshot.docs.length === 0) return;
+  const participantRoomIds = snapshot.docs.map(doc => doc.id);
+  snap.ref.update({ participantRoomIds });
+}
+
+exports.addSavedStateParticipantRoomIds = functions.firestore
+  .document('savedStates/{docId}')
+  .onCreate(addParticipantRoomIds);
+
+exports.addReflectionResponseParticipantRoomIds = functions.firestore
+  .document('reflectionResponses/{docId}')
+  .onCreate(addParticipantRoomIds);
+
+exports.addQuizAnswerParticipantRoomIds = functions.firestore
+  .document('quizAnswers/{docId}')
+  .onCreate(addParticipantRoomIds);
+
+
+// Facilitators: for rooms
+
+async function getDbFacilitators(facilitatorIds) {
+  const promises = facilitatorIds.map(id => firestore.collection('users').doc(id).get());
+  const facilitators = await Promise.all(promises);
+  const facilitatorsData = facilitators.map(facilitator => ({ id: facilitator.id, ...facilitator.data() }));
+  return facilitatorsData;
+}
+
+/**
+ * When a room is created, add its `facilitators` field automatically based on `facilitatorIds`
+ */
+exports.addFacilitatorsOnRoomCreate = functions.firestore
+  .document('rooms/{docId}')
+  .onCreate(async (snap, context) => {
+    const facilitatorIds = snap.data().facilitatorIds;
+    const facilitators = await getDbFacilitators(facilitatorIds);
+    snap.ref.update({ facilitators });
+  });
+
+/**
+ * When a room is updated, update its `facilitators` field automatically based on `facilitatorIds`
+ * Note: be careful to prevent an infinite update loop!
+ */
+exports.updateFacilitatorsOnRoomUpdate = functions.firestore
+  .document('rooms/{docId}')
+  .onUpdate(async (change, context) => {
+    if (!change.after.exists) return;
+    const beforeFacilitatorIds = change.before.data().facilitatorIds;
+    const afterFacilitatorIds = change.after.data().facilitatorIds;
+
+    // prevent infinite update loop - proceed to update ONLY if `facilitatorIds` is changed
+    if (beforeFacilitatorIds.sort().toString() == afterFacilitatorIds.sort().toString()) return;
+
+    const facilitators = await getDbFacilitators(afterFacilitatorIds);
+    change.after.ref.update({ facilitators });
   });


### PR DESCRIPTION
For the facilitator dashboard, we will need to maintain two (one?) denormalised fields, which can be managed automatically with cloud functions:
1. `participantRoomIds` field: for the `reflectionResponses`, `quizAnswers`, and `savedStates` collections. 
2. `facilitators` field: for the `rooms` collection. (optional)

For `participantRoomIds`, it needs to be updated whenever a room's participants changes, or when a new reflection response/quiz answer/saved state is created.

For `facilitators`, it is just the full user data of the facilitators as recorded in the room's `facilitatorIds`. We might not want this field though if we decide to pull the facilitators' user information separately instead.

I've tested these functions on a separate firestore instance and they all appear to work well.