### PR TITLE
Added room to Reflections (chapter and story end) and MCQ Quiz.

### DIFF
--- a/src/components/ReflectionForm/index.js
+++ b/src/components/ReflectionForm/index.js
@@ -71,6 +71,7 @@ const ReflectionForm = ({ reflection }) => {
         answer,
         submittedAt: new Date(),
         timestamp: Date.now(),
+        ...currentUser.activeRoom  ? { room: currentUser.activeRoom } : {},
       }
     });
     try {

--- a/src/hooks/useEndOfChapter.js
+++ b/src/hooks/useEndOfChapter.js
@@ -68,6 +68,7 @@ export default function useEndOfChapter({ globalVariables = {} }) {
                 completedAt: new Date().toISOString(),
               },
             ],
+            ...currentUserDb?.activeRoom  ? { room: currentUserDb?.activeRoom } : {},
           }
 
           const nextAchievements = currentUserDb?.achievements || []

--- a/src/lib/Ink/useInk.js
+++ b/src/lib/Ink/useInk.js
@@ -185,8 +185,9 @@ const useInk = (json, characterId) => {
       userId: currentUser.id,
       character: characterId,
       id: saveDataId,
-      email: currentUser.email,
+      email: currentUser.email,      
       timestamp: new Date(),
+      ...currentUser.activeRoom  ? { room: currentUser.activeRoom } : {},
     }
 
     await createDbSavedStates(saveData, saveDataId)

--- a/src/pages/MiniGames/MultipleChoice/MultipleChoiceQuiz.js
+++ b/src/pages/MiniGames/MultipleChoice/MultipleChoiceQuiz.js
@@ -14,6 +14,7 @@ import { MINI_GAME_MAP } from '../../../models/miniGameMap';
 import AudioPlayer from "../../../music/Music"
 import Music from '../../../music/tobeyou_minigame.mp3'
 import './MultipleChoiceQuiz.scss';
+import { getDbUser } from '../../../models/userModel.js'
 
 const useStyles = makeStyles((theme) => ({
     paragraphWrapper: {
@@ -83,9 +84,19 @@ export default function MultipleChoiceQuiz(props) {
     const [isCorrectAnswer,setIsCorrectAnswer] = useState(false);
     const [isDrawerOpen,setIsDrawerOpen]=useState(false);
     const classes = useStyles();  
+    const [userFromDb, setUserFromDb] = useState(null)
 
     useEffect(() => {
+        const getUser = async () => {
+        const user = await getDbUser(currentUser.id)
+        return setUserFromDb(user)
+        }
 
+        getUser()
+    }, [currentUser.id])
+
+    useEffect(() => {
+        
     },[])
 
     const saveUserAnswer = (userAns) => {
@@ -101,9 +112,11 @@ export default function MultipleChoiceQuiz(props) {
             gameId: quiz.game_id,
             answers: userAnswers,
             createdAt: new Date(),
+            ...userFromDb?.activeRoom  ? { room: userFromDb?.activeRoom } : {},
         }
         // console.log(answerDocs);
         try {
+            console.log(answerDocs)
             await createDbAnswers(answerDocs);
         } catch (err) {
             throw new Error(`${err}`)
@@ -140,7 +153,7 @@ export default function MultipleChoiceQuiz(props) {
     const handleStartGame = () => {
         setHasGameStarted(true);
      }
-
+     
     return (
 
         <>

--- a/src/pages/ReflectionsPage/chapter/ChapterLearning.js
+++ b/src/pages/ReflectionsPage/chapter/ChapterLearning.js
@@ -126,7 +126,7 @@ const ChapterLearning = ({ setPage , reflection }) => {
           {reflection.media ?
             reflection.mediatype === "video" ?
               <a href={reflection.media} target="_blank" className={classes.link}><img src={reflection.mediaimage} className={classes.videoImage}/></a> :
-              <a href={reflection.media} target="_blank" className={classes.link}><Button variant="contained" className={classes.findOutBtn} >Find Out More</Button></a>
+              <a href={reflection.media} target="_blank" className={classes.link}><Button variant="contained" className={classes.btnFindout} >Find Out More</Button></a>
             : null
           }
       </Box>

--- a/src/pages/ReflectionsPage/shared/ReflectionForm.js
+++ b/src/pages/ReflectionsPage/shared/ReflectionForm.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useParams  , useHistory } from 'react-router-dom'
 
 import { Box, Typography, Button, CircularProgress } from '@material-ui/core'
@@ -10,6 +10,7 @@ import { createDbReflectionResponses } from "../../../models/reflectionResponseM
 
 import QUESTIONS from "../../../reflections/questions.json";
 import { useAuth } from '../../../contexts/AuthContext';
+import { getDbUser } from '../../../models/userModel.js'
 
 // First we get the viewport height and we multiple it by 1% to get a value for a vh unit
 let vh = window.innerHeight * 0.01;
@@ -100,7 +101,17 @@ const ReflectionForm = ({ reflection }) => {
   const { setSnackbar } = useSnackbar();
   const [isLoading, setIsLoading] = useState(false);
   const history = useHistory()
-  const { name  } = useParams()
+  const { name } = useParams()
+  const [userFromDb, setUserFromDb] = useState(null)
+
+    useEffect(() => {
+        const getUser = async () => {
+        const user = await getDbUser(currentUser.id)
+        return setUserFromDb(user)
+        }
+
+        getUser()
+    }, [currentUser.id])
 
   const questions = useMemo(
     () => reflection
@@ -123,6 +134,7 @@ const ReflectionForm = ({ reflection }) => {
         answer,
         submittedAt: new Date(),
         timestamp: Date.now(),
+        ...userFromDb?.activeRoom  ? { room: userFromDb?.activeRoom } : {},
       }
     });
     try {
@@ -139,6 +151,7 @@ const ReflectionForm = ({ reflection }) => {
       history.push("/chapterend/" + name + '/' + reflection.chapter)
     }
   }
+  console.log(userFromDb?.activeRoom)
 
   return (
     <Box pt={6} pb={2} className={classes.chaptWrapperContainer}>

--- a/src/pages/RoomPage/FacilitationExplainer.js
+++ b/src/pages/RoomPage/FacilitationExplainer.js
@@ -75,7 +75,7 @@ const introParagraphs = {
     "text": "If you haven't played the game yet, it's pretty simple. You'll 'be' a character and make choices in an interactive story experience. You'll also do quiz games and share reflections.",
   },
   { step:3,
-    "text": "This is a game about experiencing empathy, so you'll need to keep an open mind and heart. If a scene make you uncomfortable, consider why that might be the case before you respond. ",
+    "text": "The facilitator will lead a discussion after you play, so reflect on your experience. If a scene make you uncomfortable, consider why that might be the case. ",
   },
   { step:4,
     "text": "As this is a facilitated room, the facilitator will see all the reflections and choices made, but we will hide your actual identity from the other players. ",

--- a/src/pages/StoryEndPage/steps/LongFeedbackStep.js
+++ b/src/pages/StoryEndPage/steps/LongFeedbackStep.js
@@ -28,6 +28,7 @@ const LongFeedbackStep = ({ reflection, questions, characterId, setState, getSta
         answer,
         submittedAt: new Date(),
         timestamp: Date.now(),
+        ...currentUserDb?.activeRoom  ? { room: currentUserDb?.activeRoom } : {},
       };
     });
 
@@ -38,6 +39,7 @@ const LongFeedbackStep = ({ reflection, questions, characterId, setState, getSta
     // Update the user achievements.
 
     const currentUserDb = await getDbUser(currentUser.id);
+    console.log(currentUserDb)
 
     await updateDbUser({
       [`character_${characterId}_completed`]: true,


### PR DESCRIPTION
To do: add room to savedStates, which is problematic.
We have a technical limit on the in-game choices for the facilitated rooms that will require more time to resolve. For now, we have the MCQ game answers and the student reflections, but not the choices they made during the game. I'll explain next Tuesday - basically we only have one "save game slot" per character, so if a student plays in a room, and then leaves the room and replays the chapter, the new save game (without the room code) will overwrite their homework. the only ways around this require a lot of extra save games to be created which will confuse the game engine itself later on (because we don't have a way for the player to "load the correct save game file").