### PR TITLE
Change `room` to `roomCode` when saving active room to db

### DIFF
--- a/src/components/ReflectionForm/index.js
+++ b/src/components/ReflectionForm/index.js
@@ -71,7 +71,7 @@ const ReflectionForm = ({ reflection }) => {
         answer,
         submittedAt: new Date(),
         timestamp: Date.now(),
-        ...currentUser.activeRoom  ? { room: currentUser.activeRoom } : {},
+        ...currentUser.activeRoom  ? { roomCode: currentUser.activeRoom } : {},
       }
     });
     try {

--- a/src/hooks/useEndOfChapter.js
+++ b/src/hooks/useEndOfChapter.js
@@ -68,7 +68,7 @@ export default function useEndOfChapter({ globalVariables = {} }) {
                 completedAt: new Date().toISOString(),
               },
             ],
-            ...currentUserDb?.activeRoom  ? { room: currentUserDb?.activeRoom } : {},
+            ...currentUserDb?.activeRoom  ? { roomCode: currentUserDb?.activeRoom } : {},
           }
 
           const nextAchievements = currentUserDb?.achievements || []

--- a/src/lib/Ink/useInk.js
+++ b/src/lib/Ink/useInk.js
@@ -187,7 +187,7 @@ const useInk = (json, characterId) => {
       id: saveDataId,
       email: currentUser.email,      
       timestamp: new Date(),
-      ...currentUser.activeRoom  ? { room: currentUser.activeRoom } : {},
+      ...currentUser.activeRoom  ? { roomCode: currentUser.activeRoom } : {},
     }
 
     await createDbSavedStates(saveData, saveDataId)

--- a/src/pages/MiniGames/MultipleChoice/MultipleChoiceQuiz.js
+++ b/src/pages/MiniGames/MultipleChoice/MultipleChoiceQuiz.js
@@ -112,7 +112,7 @@ export default function MultipleChoiceQuiz(props) {
             gameId: quiz.game_id,
             answers: userAnswers,
             createdAt: new Date(),
-            ...userFromDb?.activeRoom  ? { room: userFromDb?.activeRoom } : {},
+            ...userFromDb?.activeRoom  ? { roomCode: userFromDb?.activeRoom } : {},
         }
         // console.log(answerDocs);
         try {

--- a/src/pages/ReflectionsPage/shared/ReflectionForm.js
+++ b/src/pages/ReflectionsPage/shared/ReflectionForm.js
@@ -134,7 +134,7 @@ const ReflectionForm = ({ reflection }) => {
         answer,
         submittedAt: new Date(),
         timestamp: Date.now(),
-        ...userFromDb?.activeRoom  ? { room: userFromDb?.activeRoom } : {},
+        ...userFromDb?.activeRoom  ? { roomCode: userFromDb?.activeRoom } : {},
       }
     });
     try {

--- a/src/pages/StoryEndPage/steps/LongFeedbackStep.js
+++ b/src/pages/StoryEndPage/steps/LongFeedbackStep.js
@@ -28,7 +28,7 @@ const LongFeedbackStep = ({ reflection, questions, characterId, setState, getSta
         answer,
         submittedAt: new Date(),
         timestamp: Date.now(),
-        ...currentUserDb?.activeRoom  ? { room: currentUserDb?.activeRoom } : {},
+        ...currentUserDb?.activeRoom  ? { roomCode: currentUserDb?.activeRoom } : {},
       };
     });
 


### PR DESCRIPTION
A rather minor point, but would it be possible to save the field instead as `roomCode`, following the convention of `room.code` in the rooms collection? That could help to make it more specific and avoid possible confusions with e.g. room ID or room name