### PR TITLE
Add multiline text to game instructions

### DIFF
--- a/src/pages/RoomPage/RoomDetailsPage.js
+++ b/src/pages/RoomPage/RoomDetailsPage.js
@@ -269,7 +269,9 @@ const RoomDetailsPage = () => {
           <Typography  className={classes.title}>Facilitator's Message</Typography>
         </AccordionSummary>
         <AccordionDetails>
-         <Typography paragraph={true} className={classes.body}> {room?.instructions}</Typography>           
+          <Typography className={classes.body}>
+            <pre style={{ fontFamily: 'inherit', margin: 0 }}>{room?.instructions}</pre>
+          </Typography>           
         </AccordionDetails>
       </Accordion>
         


### PR DESCRIPTION
This PR adds multiline text to game instructions (the facilitator's message), following the solution [here](https://stackoverflow.com/questions/46969060/how-to-achieve-multi-line-label-with-react-material-ui)

<img width="339" alt="Screenshot 2022-04-21 at 12 10 14 AM" src="https://user-images.githubusercontent.com/41856541/164275219-adc0484f-5fcf-43fb-889d-58d610886dc7.png">
