### PR TITLE
Fix global variables map

### DIFF
--- a/src/models/globalVarMap.js
+++ b/src/models/globalVarMap.js
@@ -1164,7 +1164,7 @@ const GLOBAL_VAR_MAP = [
             title: "Zhihao leaves the tweet as it will blow over",
             name: "chapter_1_ending",
           },
-        ]    
+        ],
         variables: [
           {
             name: 'zhihao_1_earning',


### PR DESCRIPTION
This PR adds a missing comma in `globalVarMap.js`