### PR TITLE
Add cloud function to remove email field from users on create/update

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ then run `npm start` to start the app on `localhost:3000`.
  
 The game uses Inky (by Inklestudios) as the backend for the narrative engine, and a custom React front end.
 
+### Deploying Cloud Functions
+
+To deploy the cloud functions in `/functions`:
+1. Ensure that you are logged in as the right user, by running `firebase login --reauth`
+2. Ensure that the project name being referenced in `.firebaserc` is correct
+3. Deploy the functions using `firebase deploy --only functions`
 
 ## Community
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -46,3 +46,27 @@ exports.incrementReflectionChoiceCounters = functions.firestore
       await choiceRef.update({ count: FieldValue.increment(1) });
     }
   });
+
+// Remove email field from users collection
+
+exports.removeEmailFieldFromUsersOnCreate = functions.firestore
+  .document('users/{docId}')
+  .onCreate(async (snap, context) => {
+    const { email } = snap.data();
+    if (!email) return;
+    const userRef = snap.ref;
+    await userRef.update({
+      email: FieldValue.delete(),
+    });
+  });
+
+exports.removeEmailFieldFromUsersOnUpdate = functions.firestore
+  .document('users/{docId}')
+  .onUpdate(async (change, context) => {
+    const { email } = change.after.data();
+    if (!email) return;
+    const userRef = change.after.ref;
+    await userRef.update({
+      email: FieldValue.delete(),
+    });
+  });


### PR DESCRIPTION
One way to ensure that users don't have the `email` field is to remove it automatically via a cloud function whenever a user document is created or updated. This could be a useful fallback if we're unable to be sure that we can get rid of it entirely at the code level.

To deploy the function, run `firebase deploy --only functions`. The function will not be deployed and take effect until the command has been manually run.