### PR TITLE
Add callable cloud functions for the facilitator dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ then run `npm start` to start the app on `localhost:3000`.
  
 The game uses Inky (by Inklestudios) as the backend for the narrative engine, and a custom React front end.
 
+### Deploying Firebase Functions
+
+Ensure that your version of `firebase` is at least 11.
+
+To set up the environment variables for Firebase functions,
+create `functions/.env` and set the value for `EMAILJS_ACCESS_TOKEN` to be your EmailJS private key.
+
+Deploy to Firebase with `firebase deploy --only functions`.
+When deploying, you should see in the console that the environment variables have been loaded from `.env`.
+
 
 ## Community
 

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.env

--- a/functions/index.js
+++ b/functions/index.js
@@ -2,6 +2,7 @@ const functions = require('firebase-functions');
 const admin = require('firebase-admin');
 const gcpFirestore = require('@google-cloud/firestore');
 const firestoreClient = new gcpFirestore.v1.FirestoreAdminClient();
+const axios = require('axios');
 
 admin.initializeApp();
 const firestore = admin.firestore();
@@ -76,3 +77,126 @@ exports.incrementReflectionChoiceCounters = functions.firestore
         })
   
     })
+
+// APIs for functionalities involving other users' emails
+
+function isUserFacilitatorForRoom(userId, room) {
+  const roomData = room.data()
+  return room.exists && roomData.facilitatorIds && roomData.facilitatorIds.includes(userId)
+}
+
+async function getDbRoom(roomId) {
+  const room = await firestore.collection('rooms').doc(roomId).get();
+  const roomData = room.data();
+  return { room, roomData };
+}
+
+async function sendInviteCoFacilitatorEmail(roomCode, toEmail, message) {
+  await axios.post('https://api.emailjs.com/api/v1.0/email/send',{
+    service_id: 'service_q3gnqrp',
+    template_id: 'template_6oavgta',
+    user_id: 'user_kmfKhjRSSwoovXNarQivp',
+    template_params: {
+      message: message,
+      room_code: roomCode,
+      to_email: toEmail,
+    },
+    accessToken: process.env.EMAILJS_ACCESS_TOKEN,
+  });
+}
+
+
+// Input: roomId
+// Output: list of co-facilitator emails for that room
+// Requirements: user is authenticated and is a facilitator for that room
+exports.getCoFacilitatorEmailsForRoom = functions.https
+  .onCall(async (data, context) => {
+    const userId = context.auth && context.auth.uid;
+    const { roomId } = data;
+    if (!userId) return;
+
+    const { room, roomData } = await getDbRoom(roomId);
+    if (!isUserFacilitatorForRoom(userId, room)) return;
+
+    const coFacilitatorEmails = Promise.all(roomData.facilitatorIds.map(async (coFacilitatorId) => {
+      const emailDoc = await firestore.collection('emails').doc(coFacilitatorId).get();
+      const email = emailDoc.data().email;
+      return email
+    }));
+    return coFacilitatorEmails;
+  });
+
+// Input: roomId
+// Output: map of participant user IDs to their emails for that room
+// Requirements: user is authenticated and is a facilitator for that room
+exports.getParticipantIdsToEmailsForRoom = functions.https
+  .onCall(async (data, context) => {
+    const userId = context.auth && context.auth.uid;
+    const { roomId } = data;
+    if (!userId) return;
+
+    const { room, roomData } = await getDbRoom(roomId);
+    if (!isUserFacilitatorForRoom(userId, room)) return;
+
+    const participantIdEmailMap = {};
+    await Promise.all(roomData.participantIds.map(async (participantId) => {
+      const participant = await firestore.collection('emails').doc(participantId).get();
+      const participantEmail = participant.data().email;
+      participantIdEmailMap[participantId] = participantEmail;
+    }));
+    return participantIdEmailMap;
+  });
+
+// Input: roomId, toEmail
+// Output: { success: boolean, message: string }
+// Requirements: user is authenticated and is a facilitator for that room
+exports.inviteUserToBeCofacilitatorForRoom = functions.https
+  .onCall(async (data, context) => {
+    const userId = context.auth && context.auth.uid;
+    const { roomId, toEmail } = data;
+    if (!userId) return;
+
+    const { room, roomData } = await getDbRoom(roomId);
+    if (!isUserFacilitatorForRoom(userId, room)) return;
+
+    const fromEmail = (context.auth.token && context.auth.token.email) || '<no-email>';
+    const roomCode = roomData.code;
+    const snapshot = await firestore.collection('emails').where('email', '==', toEmail).get();
+    if (snapshot.empty) {
+        // Failure (user to be invited as co-facilitator does not exist): send failure email
+      const message = `
+        You were invited by your colleague at ${fromEmail} to be a co-facilitator for the room ${roomCode} for ToBeYou.sg.
+        Unfortunately, you do not yet have an account in the game.
+        Creating an account is free and easy -
+        just go to https://game.tobeyou.sg and create an account,
+        then let your colleague know the email address that you used to register so that they can add you again.
+        Once they have added you, you can go to your facilitator dashboard to access the room.
+      `;
+      sendInviteCoFacilitatorEmail(roomCode, toEmail, message);
+      return {
+        success: false,
+        message: `There is no account with email ${toEmail}. We've sent them an email inviting them to sign up with us.`,
+      }
+    }
+
+    const toUser = snapshot.docs[0]
+    const toUserAlreadyCoFacilitatorInRoom = roomData.facilitatorIds.includes(toUser.id);
+    if (toUserAlreadyCoFacilitatorInRoom) {
+      // Failure (user to be invited as co-facilitator is already a co-facilitator already in room)
+      return {
+        success: false,
+        message: `The facilitator with email '${toEmail}' is already in the room.`
+      }
+    }
+
+    // Success (user to be invited as co-facilitator exists): add co-facilitator to room and send success email
+    const message = `
+      You have been added by your colleague at ${fromEmail} as a co-facilitator for room ${room.code} for ToBeYou.sg.
+      The room should now be available in your facilitator dashboard.
+    `;
+    sendInviteCoFacilitatorEmail(roomCode, toEmail, message);
+    return {
+      success: true,
+      message: `Success! We've sent an email to ${toEmail} to notify them that they've been added to the room.`,
+    }
+  });

--- a/functions/package.json
+++ b/functions/package.json
@@ -13,8 +13,9 @@
   },
   "main": "index.js",
   "dependencies": {
+    "axios": "^1.1.3",
     "firebase-admin": "^9.8.0",
-    "firebase-functions": "^3.14.1"
+    "firebase-functions": "^3.20.1"
   },
   "devDependencies": {
     "firebase-functions-test": "^0.2.0"


### PR DESCRIPTION
## Problem

The facilitator dashboard requires facilitators to access other users' emails in 3 ways:
- Get emails of co-facilitators in the room
- Get emails of participants in the room
- Invite another user (by email) to be a co-facilitator for the room

However, given that emails are to be extracted into a new collection, and users shouldn't be allowed to access others' emails directly, we need another means of doing the above.
 
## Solution

This PR adds 3 callable functions to do so: `getCoFacilitatorEmailsForRoom`, `getParticipantIdsToEmailsForRoom`, and `inviteUserToBeCofacilitatorForRoom`

Updated `firebase-functions` to v3.20 to allow for uploading env variables (emailJS access token)

Note that we may need to enable public access to the cloud functions, otherwise they *could* be blocked by default - see https://cloud.google.com/functions/docs/securing/managing-access-iam#allowing_unauthenticated_function_invocation and https://stackoverflow.com/questions/50278537/firebase-callable-function-cors as references

- [x] Test calling `getCoFacilitatorEmailsForRoom` - it works
- [x] Test calling `getParticipantIdsToEmailsForRoom` - it works
- [x] Test calling `inviteUserToBeCofacilitatorForRoom` - ~it appears to work on the backend but I'm not receiving the email, have we hit an emailJs quota or is something else going on? I tried sending some emails at approximately 28/10/2022 12:10am, can we verify if it worked?~ it works now after configuring emailJS settings