### PR TITLE
Remove email field before saving user to db

### DIFF
--- a/src/models/userModel.js
+++ b/src/models/userModel.js
@@ -35,6 +35,9 @@ export const getDbUser = async (objId) => {
 }
 
 export const updateDbUser = async (obj, objId) => {
+  if (obj.email) {
+    delete obj.email // prevent email field from being saved in users collection
+  }
   try {
     const userRef = firestore.collection('users').doc(objId || obj.id)
     await userRef.update(obj)


### PR DESCRIPTION
This PR removes the `email` field (if it exists) from user objects that are to be saved to the database - it acts as a fail-safe in case the object still contains an `email`

For more context, see #339