### PR TITLE
Fix email migration to handle undefined values

### DIFF
--- a/scripts/2022-10-01-migration-add-new-collection-emails.js
+++ b/scripts/2022-10-01-migration-add-new-collection-emails.js
@@ -55,7 +55,7 @@ async function up() {
   console.log('Creating emails...');
   await Promise.all(users.map(async (user) => {
     await firestore.collection('emails').doc(user.id).set({
-      email: user.email,
+      email: user.email || null,
     });
     console.log(`Created email document ${user.email} with user ID ${user.id}`)
   }));


### PR DESCRIPTION
It appears that some users don't have an `email` field, so `email` could possibly be `undefined`, but the migration to add emails is unable to support undefined fields.

This PR changes the migration such that if the user's email is undefined, null, or otherwise empty, it'll set the email field to null. Would this break anything in the upcoming fix? @gauravkeerthi 